### PR TITLE
Rename all instances of versus

### DIFF
--- a/src/sutta_processor/application/check_service/bd_reference.py
+++ b/src/sutta_processor/application/check_service/bd_reference.py
@@ -13,10 +13,10 @@ from sutta_processor.application.domain_models import (
 )
 from sutta_processor.application.domain_models.base import BaseFileAggregate
 from sutta_processor.application.domain_models.bilara_concordance.root import (
-    ConcordanceVersus,
+    ConcordanceVerses,
 )
 from sutta_processor.application.domain_models.bilara_reference.root import (
-    ReferenceVersus,
+    ReferenceVerses,
 )
 from sutta_processor.application.value_objects import UID, BaseTextKey, MsId
 from sutta_processor.shared.config import Config
@@ -182,7 +182,7 @@ class SCReferenceService:
     @classmethod
     def get_references_stem(cls, reference: BilaraReferenceAggregate) -> list:
         stems = set()
-        for verse in reference.index.values():  # type: ReferenceVersus
+        for verse in reference.index.values():  # type: ReferenceVerses
             stems.update((v.reference_root for v in verse.references))
         reference_stems = list(sorted(stems))
         log.error("Reference stems: %s", reference_stems)
@@ -190,20 +190,20 @@ class SCReferenceService:
 
     def get_wrong_pts_cs_no(self, reference: BilaraReferenceAggregate):
         ignore = {"pts-cs75", "pts-cs1.10", "pts-cs7", "pts-cs8", "pts-cs12"}
-        for versus in reference.index.values():  # type: ReferenceVersus
-            if not versus.uid.key.raw.startswith("dn"):
+        for verses in reference.index.values():  # type: ReferenceVerses
+            if not verses.uid.key.raw.startswith("dn"):
                 continue
-            elif not versus.references.pts_cs:
+            elif not verses.references.pts_cs:
                 # No pts_cs reference in the reference list so skip it
                 continue
-            elif versus.references.pts_cs in ignore:
+            elif verses.references.pts_cs in ignore:
                 continue
-            if not versus.uid.key.seq.raw.startswith(versus.references.pts_cs.pts_no):
+            if not verses.uid.key.seq.raw.startswith(verses.references.pts_cs.pts_no):
                 log.error(
                     "[%s] wrong uid '%s' for pts_cs number: %s",
                     self.name,
-                    versus.uid,
-                    versus.references.pts_cs,
+                    verses.uid,
+                    verses.references.pts_cs,
                 )
 
     def get_missing_ms_id_from_reference(self, aggregate: YuttaAggregate):
@@ -264,7 +264,7 @@ class SCReferenceService:
             # continue
             # else:
             #     log.error("Empty index for file: %s", f_aggr.f_pth)
-            # f_aggr.index[concordance_verse.uid] = ReferenceVersus(
+            # f_aggr.index[concordance_verse.uid] = ReferenceVerses(
             #     raw_uid=concordance_verse.raw_uid,
             #     verse=",".join(concordance_verse.references),
             # )
@@ -362,8 +362,8 @@ class SCReferenceService:
     @classmethod
     def get_wrong_segments_based_on_nya(cls, reference: BilaraReferenceAggregate):
         wrong_keys = set()
-        for uid, ref_versus in reference.index.items():
-            nya_id = ref_versus.references.nya
+        for uid, ref_verses in reference.index.items():
+            nya_id = ref_verses.references.nya
             if not nya_id:
                 continue
             is_uid_ok = nya_id == f"nya{uid.key.seq[0]}"

--- a/src/sutta_processor/application/check_service/uid_renumber.py
+++ b/src/sutta_processor/application/check_service/uid_renumber.py
@@ -11,7 +11,7 @@ from sutta_processor.application.domain_models import (
 )
 from sutta_processor.application.domain_models.bilara_html.root import (
     BilaraHtmlFileAggregate,
-    HtmlVersus,
+    HtmlVerses,
 )
 from sutta_processor.application.domain_models.bilara_root.root import FileAggregate
 from sutta_processor.application.value_objects import UID
@@ -30,22 +30,22 @@ class UidRenumber(ServiceBase):
     def process_file_aggregate(self, file_aggregate: FileAggregate):
         def update_root_file_index():
             new_index = {}
-            for uid, versus in file_aggregate.index.items():
+            for uid, verses in file_aggregate.index.items():
                 if uid.key.key.startswith("foo"):
                     log.error("Replacing foo with uid: %s", foo_uid_to_replace)
                     new_uid = foo_uid_to_replace
                 else:
                     new_uid = uid
-                new_index[new_uid] = versus
+                new_index[new_uid] = verses
             file_aggregate._replace_index(index=new_index)
 
         def update_html_file_index(next_uid):
             html_f_aggregate: BilaraHtmlFileAggregate = self.html.file_index[next_uid]
             new_index = {}
             prev_uid = None
-            for uid, versus in html_f_aggregate.index.items():
+            for uid, verses in html_f_aggregate.index.items():
                 if uid == next_uid:
-                    verse = HtmlVersus(
+                    verse = HtmlVerses(
                         raw_uid=foo_uid_to_replace,
                         verse="<p class='uddana-intro'>{}</p>",
                     )
@@ -53,7 +53,7 @@ class UidRenumber(ServiceBase):
                     new_index[foo_uid_to_replace] = verse
                     new_index[prev_uid] = prev_verse
 
-                new_index[uid] = versus
+                new_index[uid] = verses
                 prev_uid = uid
             html_f_aggregate._replace_index(index=new_index)
 
@@ -72,7 +72,7 @@ class UidRenumber(ServiceBase):
 
             elif foo_found:
                 # Verset form html data that is just before the foo
-                prev_html_verse: HtmlVersus = self.get_prev_html_line(uid_after_foo=uid)
+                prev_html_verse: HtmlVerses = self.get_prev_html_line(uid_after_foo=uid)
                 if "uddana-intro" in prev_html_verse.verse:
                     foo_uid_to_replace = prev_html_verse.uid
                     # We can auto fix foo by assigning uid from prev verse of html file
@@ -91,14 +91,14 @@ class UidRenumber(ServiceBase):
             # No foo was found in this file
             return
 
-    def get_prev_html_line(self, uid_after_foo: UID) -> Optional[HtmlVersus]:
+    def get_prev_html_line(self, uid_after_foo: UID) -> Optional[HtmlVerses]:
 
-        prev_verse: HtmlVersus = ""  # ...
-        for uid, versus in self.html.index.items():  # type: UID, HtmlVersus
+        prev_verse: HtmlVerses = ""  # ...
+        for uid, verses in self.html.index.items():  # type: UID, HtmlVerses
             if uid == uid_after_foo:
                 return prev_verse
             else:
-                prev_verse = versus
+                prev_verse = verses
 
     def add_aggregates(self, bilara: BilaraRootAggregate, html: BilaraHtmlAggregate):
         self.bilara = bilara

--- a/src/sutta_processor/application/domain_models/base.py
+++ b/src/sutta_processor/application/domain_models/base.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 
 
 @attr.s(frozen=True, auto_attribs=True)
-class BaseVersus(ABC):
+class BaseVerses(ABC):
     uid: UID = attr.ib(converter=UID, init=False)
     verse: Verse = attr.ib(converter=Verse)
 
@@ -33,12 +33,12 @@ class BaseVersus(ABC):
 
 @attr.s(frozen=True, auto_attribs=True)
 class BaseFileAggregate(ABC):
-    index: Dict[UID, BaseVersus]
+    index: Dict[UID, BaseVerses]
 
     errors: Dict[str, str]
 
     f_pth: Path
-    versus_class = BaseVersus
+    verses_class = BaseVerses
 
     @classmethod
     @abstractmethod
@@ -51,7 +51,7 @@ class BaseFileAggregate(ABC):
         errors = {}
         for k, v in in_dto.items():
             try:
-                mn = cls.versus_class(raw_uid=k, verse=v)
+                mn = cls.verses_class(raw_uid=k, verse=v)
                 index[mn.uid] = mn
             except SegmentIdError as e:
                 log.trace(e)
@@ -68,7 +68,7 @@ class BaseFileAggregate(ABC):
             data = json.load(f)
         return cls.from_dict(in_dto=data, f_pth=f_pth)
 
-    def _replace_index(self, index: Dict[UID, BaseVersus]):
+    def _replace_index(self, index: Dict[UID, BaseVerses]):
         """
         Insecure - won't update the aggregate index. Use only to update file once, and
           then reload the whole thing.
@@ -83,7 +83,7 @@ class BaseFileAggregate(ABC):
 
 @attr.s(frozen=True)
 class TextCompareMixin:
-    index: Dict[UID, BaseVersus]
+    index: Dict[UID, BaseVerses]
 
     _text_index: Dict[VerseTokens, Set[UID]]
     _text_head_index: Dict[VerseTokens.HeadKey, Set[VerseTokens]]
@@ -129,7 +129,7 @@ class TextCompareMixin:
 class BaseRootAggregate(ABC, TextCompareMixin):
     """Translation aggregate has different index structure."""
 
-    index: Dict[UID, BaseVersus]
+    index: Dict[UID, BaseVerses]
     file_aggregates: Tuple[BaseFileAggregate]
 
     _LOAD_INFO = "* [%s] Loaded '%s' UIDs"

--- a/src/sutta_processor/application/domain_models/bilara_comments/root.py
+++ b/src/sutta_processor/application/domain_models/bilara_comments/root.py
@@ -6,20 +6,20 @@ import attr
 from sutta_processor.application.domain_models.base import (
     BaseFileAggregate,
     BaseRootAggregate,
-    BaseVersus,
+    BaseVerses,
 )
 
 log = logging.getLogger(__name__)
 
 
 @attr.s(frozen=True, auto_attribs=True)
-class CommentVersus(BaseVersus):
+class CommentVerses(BaseVerses):
     pass
 
 
 @attr.s(frozen=True, auto_attribs=True)
 class BilaraCommentFileAggregate(BaseFileAggregate):
-    versus_class = CommentVersus
+    verses_class = CommentVerses
 
     @classmethod
     def from_dict(cls, in_dto: dict, f_pth: Path) -> "BilaraCommentFileAggregate":

--- a/src/sutta_processor/application/domain_models/bilara_concordance/root.py
+++ b/src/sutta_processor/application/domain_models/bilara_concordance/root.py
@@ -9,7 +9,7 @@ import attr
 from sutta_processor.application.domain_models.base import (
     BaseFileAggregate,
     BaseRootAggregate,
-    BaseVersus,
+    BaseVerses,
 )
 from sutta_processor.application.value_objects import (
     UID,
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 
 
 @attr.s(frozen=True, auto_attribs=True)
-class ConcordanceVersus(BaseVersus):
+class ConcordanceVerses(BaseVerses):
     uid: UID = attr.ib(init=False)
     verse: Verse
 
@@ -40,8 +40,8 @@ class ConcordanceVersus(BaseVersus):
 
 @attr.s(frozen=True, auto_attribs=True)
 class ConcordanceFileAggregate(BaseFileAggregate):
-    index: Dict[UID, ConcordanceVersus]
-    versus_class = ConcordanceVersus
+    index: Dict[UID, ConcordanceVerses]
+    verses_class = ConcordanceVerses
 
     @classmethod
     def from_dict(cls, in_dto: dict, f_pth: Path) -> "ConcordanceFileAggregate":
@@ -65,7 +65,7 @@ class ConcordanceAggregate(BaseRootAggregate):
     # cs are counted from the first paragraph, but are not unique through whole texts,
     # that's wy we need BaseTextKey to see which sutta it is.
     ref_index: Dict[BaseTextKey, Dict[ScID, ReferencesConcordance]]
-    index: Dict[UID, ConcordanceVersus]
+    index: Dict[UID, ConcordanceVerses]
 
     @classmethod
     def from_path(cls, root_pth: Path) -> "ConcordanceAggregate":
@@ -74,13 +74,13 @@ class ConcordanceAggregate(BaseRootAggregate):
         log.info(cls._LOAD_INFO, cls.__name__, len(index))
 
         ref_index = defaultdict(dict)
-        for uid, versus in index.items():  # type: UID, ConcordanceVersus
-            if versus.references.sc_id:
-                ref_index[uid.key.key][versus.references.sc_id] = versus.references
-            elif versus.references.pts_pli:
+        for uid, verses in index.items():  # type: UID, ConcordanceVerses
+            if verses.references.sc_id:
+                ref_index[uid.key.key][verses.references.sc_id] = verses.references
+            elif verses.references.pts_pli:
                 ref_index[uid.key.key.head][
-                    versus.references.pts_pli
-                ] = versus.references
+                    verses.references.pts_pli
+                ] = verses.references
         return cls(
             file_aggregates=(f_aggregate,), index=index, ref_index=dict(ref_index),
         )

--- a/src/sutta_processor/application/domain_models/bilara_html/root.py
+++ b/src/sutta_processor/application/domain_models/bilara_html/root.py
@@ -7,7 +7,7 @@ import attr
 from sutta_processor.application.domain_models.base import (
     BaseFileAggregate,
     BaseRootAggregate,
-    BaseVersus,
+    BaseVerses,
 )
 from sutta_processor.application.value_objects import UID, HtmlVerse
 
@@ -15,13 +15,13 @@ log = logging.getLogger(__name__)
 
 
 @attr.s(frozen=True, auto_attribs=True)
-class HtmlVersus(BaseVersus):
+class HtmlVerses(BaseVerses):
     verse: HtmlVerse = attr.ib(converter=HtmlVerse)
 
 
 @attr.s(frozen=True, auto_attribs=True)
 class BilaraHtmlFileAggregate(BaseFileAggregate):
-    versus_class = HtmlVersus
+    verses_class = HtmlVerses
 
     @classmethod
     def from_dict(cls, in_dto: dict, f_pth: Path) -> "BilaraHtmlFileAggregate":
@@ -31,7 +31,7 @@ class BilaraHtmlFileAggregate(BaseFileAggregate):
 
 @attr.s(frozen=True, auto_attribs=True, str=False)
 class BilaraHtmlAggregate(BaseRootAggregate):
-    index: Dict[UID, HtmlVersus]
+    index: Dict[UID, HtmlVerses]
     file_aggregates: Tuple[BilaraHtmlFileAggregate]
 
     file_index: Dict[UID, BilaraHtmlFileAggregate]

--- a/src/sutta_processor/application/domain_models/bilara_reference/root.py
+++ b/src/sutta_processor/application/domain_models/bilara_reference/root.py
@@ -8,7 +8,7 @@ from natsort import natsorted
 from sutta_processor.application.domain_models.base import (
     BaseFileAggregate,
     BaseRootAggregate,
-    BaseVersus,
+    BaseVerses,
 )
 from sutta_processor.application.value_objects import UID, References, Verse
 
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 
 
 @attr.s(frozen=True, auto_attribs=True)
-class ReferenceVersus(BaseVersus):
+class ReferenceVerses(BaseVerses):
     uid: UID = attr.ib(init=False)
     verse: Verse
 
@@ -30,8 +30,8 @@ class ReferenceVersus(BaseVersus):
 
 @attr.s(frozen=True, auto_attribs=True)
 class BilaraReferenceFileAggregate(BaseFileAggregate):
-    versus_class = ReferenceVersus
-    index: Dict[UID, ReferenceVersus]
+    verses_class = ReferenceVerses
+    index: Dict[UID, ReferenceVerses]
 
     @classmethod
     def from_dict(cls, in_dto: dict, f_pth: Path) -> "BilaraReferenceFileAggregate":
@@ -52,7 +52,7 @@ class BilaraReferenceFileAggregate(BaseFileAggregate):
 
 @attr.s(frozen=True, auto_attribs=True, str=False)
 class BilaraReferenceAggregate(BaseRootAggregate):
-    index: Dict[UID, ReferenceVersus]
+    index: Dict[UID, ReferenceVerses]
 
     @classmethod
     def from_path(cls, root_pth: Path) -> "BilaraReferenceAggregate":

--- a/src/sutta_processor/application/domain_models/bilara_root/root.py
+++ b/src/sutta_processor/application/domain_models/bilara_root/root.py
@@ -6,7 +6,7 @@ import attr
 from sutta_processor.application.domain_models.base import (
     BaseFileAggregate,
     BaseRootAggregate,
-    BaseVersus,
+    BaseVerses,
 )
 from sutta_processor.application.value_objects import RawVerse
 
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 
 
 @attr.s(frozen=True, auto_attribs=True)
-class Versus(BaseVersus):
+class Verses(BaseVerses):
     raw_verse: RawVerse = attr.ib(converter=RawVerse, init=False)
 
     def __attrs_post_init__(self):
@@ -24,7 +24,7 @@ class Versus(BaseVersus):
 
 @attr.s(frozen=True, auto_attribs=True)
 class FileAggregate(BaseFileAggregate):
-    versus_class = Versus
+    verses_class = Verses
 
     @classmethod
     def from_dict(cls, in_dto: dict, f_pth: Path) -> "FileAggregate":

--- a/src/sutta_processor/application/domain_models/bilara_translation/root.py
+++ b/src/sutta_processor/application/domain_models/bilara_translation/root.py
@@ -7,7 +7,7 @@ import attr
 from sutta_processor.application.domain_models.base import (
     BaseFileAggregate,
     BaseRootAggregate,
-    BaseVersus,
+    BaseVerses,
 )
 from sutta_processor.application.value_objects import UID
 
@@ -15,13 +15,13 @@ log = logging.getLogger(__name__)
 
 
 @attr.s(frozen=True, auto_attribs=True)
-class TranslationVersus(BaseVersus):
+class TranslationVerses(BaseVerses):
     pass
 
 
 @attr.s(frozen=True, auto_attribs=True)
 class BilaraTranslationFileAggregate(BaseFileAggregate):
-    versus_class = TranslationVersus
+    verses_class = TranslationVerses
 
     @classmethod
     def from_dict(cls, in_dto: dict, f_pth: Path) -> "BilaraTranslationFileAggregate":
@@ -31,7 +31,7 @@ class BilaraTranslationFileAggregate(BaseFileAggregate):
 
 @attr.s(frozen=True, auto_attribs=True, str=False)
 class BilaraTranslationAggregate(BaseRootAggregate):
-    index: Dict[str, Dict[UID, TranslationVersus]]
+    index: Dict[str, Dict[UID, TranslationVerses]]
     file_aggregates: Tuple[BilaraTranslationFileAggregate]
 
     _ERR_MSG = "Lost data, some indexes were duplicated after merging file: '{f_pth}'"

--- a/src/sutta_processor/application/domain_models/bilara_variant/root.py
+++ b/src/sutta_processor/application/domain_models/bilara_variant/root.py
@@ -7,7 +7,7 @@ import attr
 from sutta_processor.application.domain_models.base import (
     BaseFileAggregate,
     BaseRootAggregate,
-    BaseVersus,
+    BaseVerses,
 )
 from sutta_processor.application.value_objects import UID
 
@@ -15,13 +15,13 @@ log = logging.getLogger(__name__)
 
 
 @attr.s(frozen=True, auto_attribs=True)
-class VariantVersus(BaseVersus):
+class VariantVerses(BaseVerses):
     pass
 
 
 @attr.s(frozen=True, auto_attribs=True)
 class BilaraVariantFileAggregate(BaseFileAggregate):
-    versus_class = VariantVersus
+    verses_class = VariantVerses
 
     @classmethod
     def from_dict(cls, in_dto: dict, f_pth: Path) -> "BilaraVariantFileAggregate":
@@ -31,7 +31,7 @@ class BilaraVariantFileAggregate(BaseFileAggregate):
 
 @attr.s(frozen=True, auto_attribs=True, str=False)
 class BilaraVariantAggregate(BaseRootAggregate):
-    index: Dict[UID, VariantVersus]
+    index: Dict[UID, VariantVerses]
     file_aggregates: Tuple[BilaraVariantFileAggregate]
 
     _ERR_MSG = "Lost data, some indexes were duplicated after merging file: '{f_pth}'"

--- a/src/sutta_processor/application/domain_models/ms_palicanon/base.py
+++ b/src/sutta_processor/application/domain_models/ms_palicanon/base.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 
 
 @attr.s(frozen=True, auto_attribs=True)
-class PaliVersus:
+class PaliVerses:
     ms_id: MsId
     msdiv_id: PaliMsDivId
     verse: MsVerse
@@ -27,8 +27,8 @@ class PaliVersus:
 
 @attr.s(frozen=True, auto_attribs=True)
 class PaliFileAggregate:
-    versets: Tuple[PaliVersus]
-    index: Dict[MsId, PaliVersus]
+    versets: Tuple[PaliVerses]
+    index: Dict[MsId, PaliVerses]
 
     crumb: PaliCrumb
 
@@ -42,7 +42,7 @@ class PaliFileAggregate:
         raw_source = cls.get_raw_source(f_pth=f_pth)
         page = cls.get_page(raw_source=raw_source)
         crumb: PaliCrumb = cls.html_extractor.get_crumb(page=page)
-        index: Dict[MsId, PaliVersus] = cls.get_index(page=page)
+        index: Dict[MsId, PaliVerses] = cls.get_index(page=page)
         kwargs = {
             "crumb": crumb,
             "f_pth": f_pth,
@@ -53,18 +53,18 @@ class PaliFileAggregate:
         return cls(**kwargs)
 
     @classmethod
-    def get_index(cls, page: _ElementTree) -> Dict[MsId, PaliVersus]:
+    def get_index(cls, page: _ElementTree) -> Dict[MsId, PaliVerses]:
         page_paragraphs = cls.html_extractor.get_paragraphs(page=page)
-        dict_args = (cls.get_versus(paragraph=p) for p in page_paragraphs)
-        index = {ms_id: versus for ms_id, versus in dict_args}
+        dict_args = (cls.get_verses(paragraph=p) for p in page_paragraphs)
+        index = {ms_id: verses for ms_id, verses in dict_args}
         return index
 
     @classmethod
-    def get_versus(cls, paragraph: _Element) -> Tuple[MsId, PaliVersus]:
+    def get_verses(cls, paragraph: _Element) -> Tuple[MsId, PaliVerses]:
         ms_id, msdiv_id = cls.html_extractor.get_ms_msdiv(paragraph=paragraph)
         verse = cls.html_extractor.get_verse(paragraph=paragraph)
-        versus = PaliVersus(ms_id=ms_id, msdiv_id=msdiv_id, verse=verse)
-        return ms_id, versus
+        verses = PaliVerses(ms_id=ms_id, msdiv_id=msdiv_id, verse=verse)
+        return ms_id, verses
 
     @classmethod
     def get_raw_source(cls, f_pth: Path) -> str:

--- a/src/sutta_processor/application/domain_models/ms_palicanon/extractors.py
+++ b/src/sutta_processor/application/domain_models/ms_palicanon/extractors.py
@@ -40,5 +40,5 @@ class PaliHtmlExtractor:
     def get_verse(cls, paragraph: _Element) -> MsVerse:
         text = paragraph.xpath("./text()")
         text = text[0] if text else ""
-        versus = MsVerse(text.strip())
-        return versus
+        verses = MsVerse(text.strip())
+        return verses

--- a/src/sutta_processor/application/domain_models/ms_palicanon/root.py
+++ b/src/sutta_processor/application/domain_models/ms_palicanon/root.py
@@ -9,7 +9,7 @@ from natsort import natsorted, ns
 from sutta_processor.application.domain_models.base import BaseRootAggregate
 from sutta_processor.application.value_objects import MsId
 
-from .base import PaliFileAggregate, PaliVersus
+from .base import PaliFileAggregate, PaliVerses
 
 log = logging.getLogger(__name__)
 
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 @attr.s(frozen=True, auto_attribs=True, str=False)
 class PaliCanonAggregate(BaseRootAggregate):
     file_aggregates: Tuple[PaliFileAggregate]
-    index: Dict[MsId, PaliVersus]
+    index: Dict[MsId, PaliVerses]
 
     _ERR_MSG = "Lost data, some indexes were duplicated after merging file: '{f_pth}'"
 

--- a/src/sutta_processor/application/domain_models/ms_yuttadhammo/base.py
+++ b/src/sutta_processor/application/domain_models/ms_yuttadhammo/base.py
@@ -7,14 +7,14 @@ from lxml.etree import _Element
 
 from sutta_processor.application.value_objects import MsId, MsVerse
 
-from ..base import BaseFileAggregate, BaseVersus
+from ..base import BaseFileAggregate, BaseVerses
 from .extractors import YuttaExtractor
 
 log = logging.getLogger(__name__)
 
 
 @attr.s(frozen=True, auto_attribs=True)
-class YuttaVersus(BaseVersus):
+class YuttaVerses(BaseVerses):
     ms_id: MsId
     verse: MsVerse = attr.ib(converter=MsVerse)
     raw_uid: None = attr.ib(init=False, default=None)
@@ -25,8 +25,8 @@ class YuttaVersus(BaseVersus):
 
 @attr.s(frozen=True, auto_attribs=True)
 class YuttaFileAggregate(BaseFileAggregate):
-    versets: Tuple[YuttaVersus]
-    index: Dict[MsId, YuttaVersus]
+    versets: Tuple[YuttaVerses]
+    index: Dict[MsId, YuttaVerses]
 
     raw_xml: str
     raw_html: str
@@ -42,7 +42,7 @@ class YuttaFileAggregate(BaseFileAggregate):
         """
         raw_html = cls.get_raw_source(f_pth=f_pth)
         page = cls.extractor.get_page_from_html(html=raw_html)
-        index: Dict[MsId, YuttaVersus] = cls.get_index(page=page)
+        index: Dict[MsId, YuttaVerses] = cls.get_index(page=page)
 
         kwargs = {
             "f_pth": f_pth,
@@ -59,18 +59,18 @@ class YuttaFileAggregate(BaseFileAggregate):
         return cls(**in_dto)
 
     @classmethod
-    def get_index(cls, page: _Element) -> Dict[MsId, YuttaVersus]:
+    def get_index(cls, page: _Element) -> Dict[MsId, YuttaVerses]:
         id_nodes = cls.extractor.get_id_nodes(page=page)
-        dict_args = (cls.get_versus(node=n) for n in id_nodes)
-        index = {ms_id: versus for ms_id, versus in dict_args}
+        dict_args = (cls.get_verses(node=n) for n in id_nodes)
+        index = {ms_id: verses for ms_id, verses in dict_args}
         return index
 
     @classmethod
-    def get_versus(cls, node: _Element) -> Tuple[MsId, YuttaVersus]:
+    def get_verses(cls, node: _Element) -> Tuple[MsId, YuttaVerses]:
         ms_id = MsId.from_xml_id(cls.extractor.get_ms_id(node=node))
         verse = MsVerse(cls.extractor.get_verse(node=node))
-        versus = YuttaVersus(ms_id=ms_id, verse=verse)
-        return ms_id, versus
+        verses = YuttaVerses(ms_id=ms_id, verse=verse)
+        return ms_id, verses
 
     @property
     def html_cleaned(self) -> str:

--- a/src/sutta_processor/application/domain_models/ms_yuttadhammo/extractors.py
+++ b/src/sutta_processor/application/domain_models/ms_yuttadhammo/extractors.py
@@ -75,8 +75,8 @@ class YuttaExtractor:
         }
         text_parts = node.xpath(".//text()")
         cb = handlers.get(len(text_parts), cls.handle_len7_verse)
-        versus = cb(text_parts=text_parts)
-        return versus
+        verses = cb(text_parts=text_parts)
+        return verses
 
     @classmethod
     def get_str_from_parts(cls, parts: List[str]) -> str:

--- a/src/sutta_processor/application/domain_models/ms_yuttadhammo/root.py
+++ b/src/sutta_processor/application/domain_models/ms_yuttadhammo/root.py
@@ -10,7 +10,7 @@ from sutta_processor.application.domain_models.base import BaseRootAggregate
 from sutta_processor.application.value_objects import MsId
 
 from ...value_objects.verse import VerseTokens
-from .base import YuttaFileAggregate, YuttaVersus
+from .base import YuttaFileAggregate, YuttaVerses
 
 log = logging.getLogger(__name__)
 
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 @attr.s(frozen=True, auto_attribs=True, str=False)
 class YuttaAggregate(BaseRootAggregate):
     file_aggregates: Tuple[YuttaFileAggregate]
-    index: Dict[MsId, YuttaVersus]
+    index: Dict[MsId, YuttaVerses]
 
     _text_index: Dict[VerseTokens, Set[MsId]] = attr.ib(init=False)
     _text_head_index: Dict[VerseTokens.HeadKey, Set[VerseTokens]] = attr.ib(init=False)

--- a/src/sutta_processor/application/use_cases/bilara_check_root.py
+++ b/src/sutta_processor/application/use_cases/bilara_check_root.py
@@ -14,5 +14,5 @@ def bilara_check_root(cfg: Config):
     cfg.check: CheckService
     root_aggregate: BilaraRootAggregate = cfg.repo.bilara.get_root()
     cfg.check.check_uid_sequence_in_file(aggregate=root_aggregate)
-    diff = cfg.check.get_duplicated_versus_next_to_each_other(aggregate=root_aggregate)
+    diff = cfg.check.get_duplicated_verses_next_to_each_other(aggregate=root_aggregate)
     diff = cfg.check.get_empty_verses(aggregate=root_aggregate)

--- a/src/sutta_processor/shared/config.py
+++ b/src/sutta_processor/shared/config.py
@@ -54,7 +54,7 @@ class ExcludeRepo:
     check_uid_sequence_in_file: set = attr.ib(default=set())
     get_unknown_variants: set = attr.ib(default=set())
     get_wrong_uid_with_arrow: set = attr.ib(default=set())
-    get_duplicated_versus_next_to_each_other: set = attr.ib(default=set())
+    get_duplicated_verses_next_to_each_other: set = attr.ib(default=set())
 
     @classmethod
     def from_dict(cls, data: dict) -> "ExcludeRepo":


### PR DESCRIPTION
I discovered that the plural of "verse" ("verses") was misspelled as "versus."  I changed every occurrence I found in the repo.   I ran the script locally, and it didn't crash.  The `run_all_checks` function has been failing for me.  It might be because I have repos out of sync, though, and therefore have bad data.