### PR TITLE
Filter out unsupported languages and directories in per-file scope.

### DIFF
--- a/src/sutta_processor/application/domain_models/base.py
+++ b/src/sutta_processor/application/domain_models/base.py
@@ -138,7 +138,7 @@ class BaseRootAggregate(ABC, TextCompareMixin):
     _ERR_MSG = "Lost data, some indexes were duplicated after merging file: '{f_pth}'"
 
     @classmethod
-    def _file_paths_from_dir(cls, exclude_dirs: List[str], root_pth: Path) -> List[Path]:
+    def _file_paths_from_dir(cls, exclude_dirs: List[Path], root_pth: Path) -> List[Path]:
         """A helper function to get the paths to files contained in the root_path directory."""
         temp_files = []
         for root_dir, sub_dirs, dir_files in os.walk(root_pth):
@@ -175,7 +175,7 @@ class BaseRootAggregate(ABC, TextCompareMixin):
     @classmethod
     def _from_path(
         cls,
-        exclude_dirs: List[str],
+        exclude_dirs: List[Path],
         root_pth: Path,
         file_aggregate_cls,
     ) -> Tuple[tuple, dict, dict]:
@@ -195,7 +195,8 @@ class BaseRootAggregate(ABC, TextCompareMixin):
         return tuple(file_aggregates), index, errors
 
     @classmethod
-    def _from_file_paths(cls, file_paths: List[Path], file_aggregate_cls) -> Tuple[tuple, dict, dict]:
+    def _from_file_paths(cls, exclude_dirs: List[Path], file_paths: List[Path],
+                         file_aggregate_cls) -> Tuple[tuple, dict, dict]:
         """This function only operates on the files contained in file_paths, as opposed to all files in a directory,
         as is done by _from_path. This was added to allow running tests exclusively on files changed as part of a
         commit, instead of all files in a commit."""
@@ -203,7 +204,15 @@ class BaseRootAggregate(ABC, TextCompareMixin):
         index = {}
         errors = {}
 
-        all_files = natsorted(file_paths, alg=ns.PATH)
+        # Creating new list to avoid changing file_paths in place
+        filtered_files = file_paths
+        # Filter our files from directories we don't want to process
+        for ex_dir in exclude_dirs:
+            for file in file_paths:
+                if str(ex_dir) in str(file):
+                    filtered_files.remove(file)
+
+        all_files = natsorted(filtered_files, alg=ns.PATH)
         c: Counter = Counter(ok=0, error=0, all=len(all_files))
         for i, f_pth in enumerate(all_files):  # type: int, Path
             try:

--- a/src/sutta_processor/application/domain_models/base.py
+++ b/src/sutta_processor/application/domain_models/base.py
@@ -204,6 +204,8 @@ class BaseRootAggregate(ABC, TextCompareMixin):
                 if str(ex_dir) in str(file):
                     filtered_files.remove(file)
 
+        return filtered_files
+
     @classmethod
     def _from_file_paths(cls, exclude_dirs: List[Path], file_paths: List[Path],
                          file_aggregate_cls) -> Tuple[tuple, dict, dict]:

--- a/src/sutta_processor/application/domain_models/base.py
+++ b/src/sutta_processor/application/domain_models/base.py
@@ -195,6 +195,16 @@ class BaseRootAggregate(ABC, TextCompareMixin):
         return tuple(file_aggregates), index, errors
 
     @classmethod
+    def _filter_exclude_dirs(cls, exclude_dirs: List[Path], file_paths: List[Path]) -> List[Path]:
+        # Creating new list to avoid changing file_paths in place
+        filtered_files = file_paths
+        # Filter our files from directories we don't want to process
+        for ex_dir in exclude_dirs:
+            for file in file_paths:
+                if str(ex_dir) in str(file):
+                    filtered_files.remove(file)
+
+    @classmethod
     def _from_file_paths(cls, exclude_dirs: List[Path], file_paths: List[Path],
                          file_aggregate_cls) -> Tuple[tuple, dict, dict]:
         """This function only operates on the files contained in file_paths, as opposed to all files in a directory,
@@ -204,13 +214,7 @@ class BaseRootAggregate(ABC, TextCompareMixin):
         index = {}
         errors = {}
 
-        # Creating new list to avoid changing file_paths in place
-        filtered_files = file_paths
-        # Filter our files from directories we don't want to process
-        for ex_dir in exclude_dirs:
-            for file in file_paths:
-                if str(ex_dir) in str(file):
-                    filtered_files.remove(file)
+        filtered_files = cls._filter_exclude_dirs(exclude_dirs=exclude_dirs, file_paths=file_paths)
 
         all_files = natsorted(filtered_files, alg=ns.PATH)
         c: Counter = Counter(ok=0, error=0, all=len(all_files))

--- a/src/sutta_processor/application/domain_models/bilara_comments/root.py
+++ b/src/sutta_processor/application/domain_models/bilara_comments/root.py
@@ -31,7 +31,7 @@ class BilaraCommentFileAggregate(BaseFileAggregate):
 @attr.s(frozen=True, auto_attribs=True, str=False)
 class BilaraCommentAggregate(BaseRootAggregate):
     @classmethod
-    def from_path(cls, exclude_dirs: List[str], root_pth: Path) -> "BilaraCommentAggregate":
+    def from_path(cls, exclude_dirs: List[Path], root_pth: Path) -> "BilaraCommentAggregate":
         file_aggregates, index, errors = cls._from_path(
             exclude_dirs=exclude_dirs,
             root_pth=root_pth,
@@ -41,7 +41,7 @@ class BilaraCommentAggregate(BaseRootAggregate):
         return cls(file_aggregates=tuple(file_aggregates), index=index)
 
     @classmethod
-    def from_file_paths(cls, exclude_dirs: List[str], file_paths: List[Path]) -> "BilaraCommentAggregate":
+    def from_file_paths(cls, exclude_dirs: List[Path], file_paths: List[Path]) -> "BilaraCommentAggregate":
         file_aggregates, index, errors = cls._from_file_paths(
             exclude_dirs=exclude_dirs,
             file_paths=file_paths,

--- a/src/sutta_processor/application/domain_models/bilara_html/root.py
+++ b/src/sutta_processor/application/domain_models/bilara_html/root.py
@@ -39,7 +39,7 @@ class BilaraHtmlAggregate(BaseRootAggregate):
     _ERR_MSG = "Lost data, some indexes were duplicated after merging file: '{f_pth}'"
 
     @classmethod
-    def from_path(cls, exclude_dirs: List[str], root_pth: Path) -> "BilaraHtmlAggregate":
+    def from_path(cls, exclude_dirs: List[Path], root_pth: Path) -> "BilaraHtmlAggregate":
         file_aggregates, index, errors = cls._from_path(
             exclude_dirs=exclude_dirs,
             root_pth=root_pth,
@@ -57,7 +57,7 @@ class BilaraHtmlAggregate(BaseRootAggregate):
         return cls(file_aggregates=file_aggregates, index=index, file_index=file_index)
 
     @classmethod
-    def from_file_paths(cls, exclude_dirs: List[str], file_paths: List[Path]) -> "BilaraHtmlAggregate":
+    def from_file_paths(cls, exclude_dirs: List[Path], file_paths: List[Path]) -> "BilaraHtmlAggregate":
         """A version of the from_path function that works on a list of files as a pathlib.Path obect."""
         file_aggregates, index, errors = cls._from_file_paths(
             exclude_dirs=exclude_dirs,

--- a/src/sutta_processor/application/domain_models/bilara_reference/root.py
+++ b/src/sutta_processor/application/domain_models/bilara_reference/root.py
@@ -55,7 +55,7 @@ class BilaraReferenceAggregate(BaseRootAggregate):
     index: Dict[UID, ReferenceVerses]
 
     @classmethod
-    def from_path(cls, exclude_dirs: List[str], root_pth: Path) -> "BilaraReferenceAggregate":
+    def from_path(cls, exclude_dirs: List[Path], root_pth: Path) -> "BilaraReferenceAggregate":
         file_aggregates, index, errors = cls._from_path(
             exclude_dirs=exclude_dirs,
             root_pth=root_pth,
@@ -65,7 +65,7 @@ class BilaraReferenceAggregate(BaseRootAggregate):
         return cls(file_aggregates=tuple(file_aggregates), index=index)
 
     @classmethod
-    def from_file_paths(cls, exclude_dirs: List[str], file_paths: List[Path]) -> "BilaraReferenceAggregate":
+    def from_file_paths(cls, exclude_dirs: List[Path], file_paths: List[Path]) -> "BilaraReferenceAggregate":
         file_aggregates, index, errors = cls._from_file_paths(
             exclude_dirs=exclude_dirs,
             file_paths=file_paths,

--- a/src/sutta_processor/application/domain_models/bilara_translation/root.py
+++ b/src/sutta_processor/application/domain_models/bilara_translation/root.py
@@ -37,7 +37,7 @@ class BilaraTranslationAggregate(BaseRootAggregate):
     _ERR_MSG = "Lost data, some indexes were duplicated after merging file: '{f_pth}'"
 
     @classmethod
-    def from_path(cls, exclude_dirs: List[str], root_pth: Path) -> "BilaraCommentAggregate":
+    def from_path(cls, exclude_dirs: List[Path], root_pth: Path) -> "BilaraCommentAggregate":
         file_aggregates, index, errors = cls._from_path(
             exclude_dirs=exclude_dirs,
             root_pth=root_pth,
@@ -50,7 +50,7 @@ class BilaraTranslationAggregate(BaseRootAggregate):
         return cls(file_aggregates=file_aggregates, index=index)
 
     @classmethod
-    def from_file_paths(cls, exclude_dirs: List[str], file_paths: List[Path]) -> "BilaraCommentAggregate":
+    def from_file_paths(cls, exclude_dirs: List[Path], file_paths: List[Path]) -> "BilaraCommentAggregate":
         file_aggregates, index, errors = cls._from_file_paths(
             exclude_dirs=exclude_dirs,
             file_paths=file_paths,

--- a/src/sutta_processor/application/domain_models/bilara_variant/root.py
+++ b/src/sutta_processor/application/domain_models/bilara_variant/root.py
@@ -37,7 +37,7 @@ class BilaraVariantAggregate(BaseRootAggregate):
     _ERR_MSG = "Lost data, some indexes were duplicated after merging file: '{f_pth}'"
 
     @classmethod
-    def from_path(cls, exclude_dirs: List[str], root_pth: Path) -> "BilaraCommentAggregate":
+    def from_path(cls, exclude_dirs: List[Path], root_pth: Path) -> "BilaraCommentAggregate":
         file_aggregates, index, errors = cls._from_path(
             exclude_dirs=exclude_dirs,
             root_pth=root_pth,
@@ -47,7 +47,7 @@ class BilaraVariantAggregate(BaseRootAggregate):
         return cls(file_aggregates=tuple(file_aggregates), index=index)
 
     @classmethod
-    def from_file_paths(cls, exclude_dirs: List[str], file_paths: List[Path]) -> "BilaraCommentAggregate":
+    def from_file_paths(cls, exclude_dirs: List[Path], file_paths: List[Path]) -> "BilaraCommentAggregate":
         file_aggregates, index, errors = cls._from_file_paths(
             exclude_dirs=exclude_dirs,
             file_paths=file_paths,

--- a/src/sutta_processor/shared/config.py
+++ b/src/sutta_processor/shared/config.py
@@ -82,11 +82,11 @@ class ExcludeRepo:
 @attr.s(frozen=True, auto_attribs=True)
 class Config:
     # Not setting default so that exclude_dirs must be included.
-    exclude_dirs: List[str] = attr.ib()
+    exclude_dirs: List[Path] = attr.ib()
     # Not setting default so that exclude_filepath must be included.  We need this to remove false positives.
     exclude_filepath: Path = attr.ib()
     # A list of folder names, where each folder has files in a certain language.
-    bilara_root_langs: List[str] = attr.ib()
+    bilara_root_langs: List[Path] = attr.ib()
 
     exec_module: str = attr.ib(validator=use_case_present)
 


### PR DESCRIPTION
After reverting Bhane Sujato's revert of the 27th, I put `master` back into the state where my `research/per-file-tests` branch had been merged into `master`.  Rather than try any more tricky git-fu, I simply rebased this branch on `master` and added the missing features to this branch, and then opened this PR.